### PR TITLE
fix: deploy custom cadvisor image with pvc container device_info mapping

### DIFF
--- a/charts/costgraph-operator/Chart.lock
+++ b/charts/costgraph-operator/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.27.1
-digest: sha256:e7d1012e5e0c168152bf31a78201412ace9181b3e1409d2fef03c47a272fb066
-generated: "2026-02-11T09:46:23.549839514Z"
+- name: cadvisor
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.1.13
+digest: sha256:c26e65b8c0e137114855071616095d639bce503d01438bb65c0aee6b5197d757
+generated: "2026-03-05T17:51:05.641137209Z"

--- a/charts/costgraph-operator/Chart.yaml
+++ b/charts/costgraph-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: costgraph-operator
 description: A Helm chart for the Costgraph operator
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.0"
 
 dependencies:

--- a/charts/costgraph-operator/Chart.yaml
+++ b/charts/costgraph-operator/Chart.yaml
@@ -10,3 +10,7 @@ dependencies:
     version: "5.27.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
+  - name: cadvisor
+    version: "0.1.*"
+    repository: https://charts.bitnami.com/bitnami
+    condition: cadvisor.enabled

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -1,6 +1,6 @@
 # costgraph-operator
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for the Costgraph operator
 

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -8,16 +8,19 @@ A Helm chart for the Costgraph operator
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.bitnami.com/bitnami | cadvisor | 0.1.* |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 5.27.* |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| cadvisor | object | `{"enabled":true,"image":{"registry":"ghcr.io","repository":"baselinehq/cadvisor","tag":"v0.56.2-baseline"}}` | ------------------------------------------------------------------------ |
 | fullnameOverride | string | `""` |  |
 | global.apiKey | string | `""` |  |
 | global.clusterName | string | `""` |  |
 | global.namespace | string | `"costgraph"` |  |
+| global.security.allowInsecureImages | bool | `true` |  |
 | imagePullSecrets | list | `[]` |  |
 | kube-state-metrics | object | `{"enabled":true}` | ------------------------------------------------------------------------ |
 | nameOverride | string | `""` |  |

--- a/charts/costgraph-operator/values.yaml
+++ b/charts/costgraph-operator/values.yaml
@@ -5,6 +5,9 @@ global:
   clusterName: ""
   apiKey: ""
   namespace: "costgraph"
+  # Flag to enable use of our custom image in the cadvisor chart
+  security:
+    allowInsecureImages: true
 
 imagePullSecrets: []
 nameOverride: ""
@@ -22,6 +25,17 @@ serviceAccount:
 # --------------------------------------------------------------------------
 kube-state-metrics:
   enabled: true
+
+# --------------------------------------------------------------------------
+# cadvisor (subchart from bitnami)
+# See: https://github.com/bitnami/charts/tree/main/bitnami/cadvisor
+# --------------------------------------------------------------------------
+cadvisor:
+  enabled: true
+  image:
+    registry: ghcr.io
+    repository: baselinehq/cadvisor
+    tag: "v0.56.2-baseline"
 
 # --------------------------------------------------------------------------
 # costgraph-operator-kubernetes deployment


### PR DESCRIPTION
The hope is to return to the base image once https://github.com/google/cadvisor/pull/3844 is merged