### PR TITLE
fix: bump cadvisor deployment version

### DIFF
--- a/charts/costgraph-operator/Chart.yaml
+++ b/charts/costgraph-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: costgraph-operator
 description: A Helm chart for the Costgraph operator
 type: application
-version: 0.1.1
-appVersion: "1.16.0"
+version: 0.1.2
+appVersion: "1.16.1"
 
 dependencies:
   - name: kube-state-metrics

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -1,6 +1,6 @@
 # costgraph-operator
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
 
 A Helm chart for the Costgraph operator
 
@@ -15,7 +15,7 @@ A Helm chart for the Costgraph operator
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cadvisor | object | `{"enabled":true,"image":{"registry":"ghcr.io","repository":"baselinehq/cadvisor","tag":"v0.56.2-baseline"}}` | ------------------------------------------------------------------------ |
+| cadvisor | object | `{"enabled":true,"image":{"registry":"ghcr.io","repository":"baselinehq/cadvisor","tag":"v0.56.3-baseline"}}` | ------------------------------------------------------------------------ |
 | fullnameOverride | string | `""` |  |
 | global.apiKey | string | `""` |  |
 | global.clusterName | string | `""` |  |

--- a/charts/costgraph-operator/values.yaml
+++ b/charts/costgraph-operator/values.yaml
@@ -35,7 +35,7 @@ cadvisor:
   image:
     registry: ghcr.io
     repository: baselinehq/cadvisor
-    tag: "v0.56.2-baseline"
+    tag: "v0.56.3-baseline"
 
 # --------------------------------------------------------------------------
 # costgraph-operator-kubernetes deployment


### PR DESCRIPTION
This pull request updates the Helm chart for the Costgraph operator, primarily to bump versions for improved compatibility and stability. The most important changes are grouped below.

Version updates:

* Updated `version` to `0.1.2` and `appVersion` to `1.16.1` in `Chart.yaml` for the Costgraph operator Helm chart.
* Updated the `cadvisor` image tag from `"v0.56.2-baseline"` to `"v0.56.3-baseline"` in `values.yaml`.