### PR TITLE
fix: deploy with updated secrets

### DIFF
--- a/charts/costgraph-operator/Chart.yaml
+++ b/charts/costgraph-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: costgraph-operator
 description: A Helm chart for the Costgraph operator
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "1.16.1"
 
 dependencies:

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -1,6 +1,6 @@
 # costgraph-operator
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
 
 A Helm chart for the Costgraph operator
 
@@ -21,6 +21,8 @@ A Helm chart for the Costgraph operator
 | fullnameOverride | string | `""` |  |
 | global.apiKey | string | `""` |  |
 | global.clusterName | string | `""` |  |
+| global.existingSecret | string | `""` |  |
+| global.existingSecretKey | string | `""` |  |
 | global.namespace | string | `"costgraph"` |  |
 | global.security.allowInsecureImages | bool | `true` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/costgraph-operator/templates/_helpers.tpl
+++ b/charts/costgraph-operator/templates/_helpers.tpl
@@ -70,6 +70,26 @@ Namespace helper
 */}}
 
 {{/*
+Resolve the name of the Secret holding the API key.
+Uses an existing secret when global.existingSecret is set; otherwise uses
+the Secret created by this chart.
+*/}}
+{{- define "costgraph-operator.apiKeySecretName" -}}
+{{- if .Values.global.existingSecret -}}
+{{- .Values.global.existingSecret -}}
+{{- else -}}
+{{- include "costgraph-operator.fullname" . -}}-credentials
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the key within the API-key Secret.
+*/}}
+{{- define "costgraph-operator.apiKeySecretKey" -}}
+{{- default "apiKey" .Values.global.existingSecretKey -}}
+{{- end }}
+
+{{/*
 
 ------------------------------------------------------------------------------
 costgraph-operator-kubernetes helpers

--- a/charts/costgraph-operator/templates/_helpers.tpl
+++ b/charts/costgraph-operator/templates/_helpers.tpl
@@ -78,15 +78,21 @@ the Secret created by this chart.
 {{- if .Values.global.existingSecret -}}
 {{- .Values.global.existingSecret -}}
 {{- else -}}
-{{- include "costgraph-operator.fullname" . -}}-credentials
+{{- printf "%s-credentials" (include "costgraph-operator.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end }}
 
 {{/*
 Resolve the key within the API-key Secret.
+When referencing a chart-managed secret the key is always "apiKey".
+existingSecretKey is only honoured when an existing secret is provided.
 */}}
 {{- define "costgraph-operator.apiKeySecretKey" -}}
+{{- if .Values.global.existingSecret -}}
 {{- default "apiKey" .Values.global.existingSecretKey -}}
+{{- else -}}
+apiKey
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/costgraph-operator/templates/operator-kubernetes-deployment.yaml
+++ b/charts/costgraph-operator/templates/operator-kubernetes-deployment.yaml
@@ -44,7 +44,10 @@ spec:
             - name: CLUSTER_NAME
               value: {{ .Values.global.clusterName | required "Cluster name must be provided" | quote }}
             - name: API_KEY
-              value: {{ .Values.global.apiKey | required "Costgraph API Key must be provided" | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "costgraph-operator.apiKeySecretName" . }}
+                  key: {{ include "costgraph-operator.apiKeySecretKey" . }}
             - name: OPERATOR_VERSION
               value: {{ .Values.operatorKubernetes.image.tag | quote }}
             {{- with .Values.operatorKubernetes.env }}

--- a/charts/costgraph-operator/templates/operator-prometheus-deployment.yaml
+++ b/charts/costgraph-operator/templates/operator-prometheus-deployment.yaml
@@ -40,7 +40,10 @@ spec:
             - name: CLUSTER_NAME
               value: {{ .Values.global.clusterName | required "Cluster name must be provided"  | quote }}
             - name: API_KEY
-              value: {{ .Values.global.apiKey | required "Costgraph API Key must be provided"  | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "costgraph-operator.apiKeySecretName" . }}
+                  key: {{ include "costgraph-operator.apiKeySecretKey" . }}
             - name: PROMETHEUS_URL
               value: "{{.Release.Name}}-kube-state-metrics.{{- include "costgraph-operator.namespace" . -}}.svc.cluster.local:8080"
             - name: REMOTE_WRITE_URL

--- a/charts/costgraph-operator/templates/secret.yaml
+++ b/charts/costgraph-operator/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.global.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "costgraph-operator.fullname" . }}-credentials
+  namespace: {{ include "costgraph-operator.namespace" . }}
+  labels:
+    {{- include "costgraph-operator.labels" . | nindent 4 }}
+type: Opaque
+data:
+  apiKey: {{ .Values.global.apiKey | required "global.apiKey must be set when global.existingSecret is not provided" | b64enc | quote }}
+{{- end }}

--- a/charts/costgraph-operator/templates/serviceaccount.yaml
+++ b/charts/costgraph-operator/templates/serviceaccount.yaml
@@ -14,7 +14,9 @@ automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: all-resources-view
+  name: {{ include "costgraph-operator.fullname" . }}-view
+  labels:
+    {{- include "costgraph-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -23,11 +25,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: costgraph
+  name: {{ include "costgraph-operator.fullname" . }}
+  labels:
+    {{- include "costgraph-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: all-resources-view
+  name: {{ include "costgraph-operator.fullname" . }}-view
 subjects:
 - kind: ServiceAccount
   name: {{ include "costgraph-operator.serviceAccountName" . }}

--- a/charts/costgraph-operator/values.yaml
+++ b/charts/costgraph-operator/values.yaml
@@ -3,7 +3,15 @@
 # Global configuration shared across all operator components.
 global:
   clusterName: ""
+  # apiKey is used to create a Secret when existingSecret is not set.
+  # Do not commit a real key here; prefer existingSecret in production.
   apiKey: ""
+  # existingSecret: name of a pre-existing Secret that contains the API key.
+  # When set, no Secret is created by this chart and apiKey is ignored.
+  existingSecret: ""
+  # existingSecretKey: key within existingSecret that holds the API key value.
+  # Defaults to "apiKey" when not specified.
+  existingSecretKey: ""
   namespace: "costgraph"
   # Flag to enable use of our custom image in the cadvisor chart
   security:


### PR DESCRIPTION
This pull request updates the `costgraph-operator` Helm chart to improve how API keys are managed and to enhance resource naming consistency and labeling. The most important changes are grouped below.

**API Key Management Improvements:**

* Added support for using an existing Kubernetes Secret for the API key via new `global.existingSecret` and `global.existingSecretKey` values in `values.yaml`. If not set, the chart now creates a Secret using `global.apiKey`. This makes deployments more secure and flexible. [[1]](diffhunk://#diff-9ca78e30b01f06a974fd8dd33ab41b5d5d7cebf083eda9ead63ba312489b4cf7R6-R14) [[2]](diffhunk://#diff-0a00d20822270e21a585365081470f400771a8b29eff97105cb6b41ec44e69d8R1-R12) [[3]](diffhunk://#diff-c4b3c1f389d912773542bcf24fa448d2fcbbf9ded71f547658c0ad840f820631R72-R91)
* Deployment manifests for both the Kubernetes and Prometheus operator components now source the API key from a Secret reference rather than directly from values, improving security. [[1]](diffhunk://#diff-02fd490a071adc5bc1e1f488af928212063ee136a79337f9229fcb047fd7c5e9L47-R50) [[2]](diffhunk://#diff-aaf7923dbe2b521b10640bcb543679cf16d22b5b40d18b3844eac9415d2aa5b3L43-R46)
* Helper templates were added to resolve the Secret name and key dynamically.

**Resource Naming and Labeling Consistency:**

* The `ClusterRole` and `ClusterRoleBinding` resources now use chart-based naming and labels for better traceability and to avoid naming collisions. [[1]](diffhunk://#diff-8b8011fcba603247db385ca5bb3571c349c7d00972da3a3e1531197f07852ce8L17-R19) [[2]](diffhunk://#diff-8b8011fcba603247db385ca5bb3571c349c7d00972da3a3e1531197f07852ce8L26-R34)

**Other:**

* Chart version bumped from `0.1.4` to `0.1.5` to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for using existing Kubernetes Secrets for API key storage
  * New config options: global.existingSecret and global.existingSecretKey
  * Chart version updated to 0.1.5

* **Improvements**
  * Chart will conditionally create a credentials Secret when no existing Secret is specified
  * Kubernetes resource names and labels are now generated dynamically and consistently across deployments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->