### PR TITLE
fix: use backend URL as a parameter for local overrides

### DIFF
--- a/charts/costgraph-operator/Chart.yaml
+++ b/charts/costgraph-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: costgraph-operator
 description: A Helm chart for the Costgraph operator
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.16.1"
 
 dependencies:

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -1,6 +1,6 @@
 # costgraph-operator
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
 
 A Helm chart for the Costgraph operator
 
@@ -20,6 +20,7 @@ A Helm chart for the Costgraph operator
 | dcgm-exporter | object | `{"enabled":false,"nodeSelector":{"accelerator":"nvidia"},"podAnnotations":{},"podLabels":{},"resources":{},"serviceMonitor":{"enabled":false},"tolerations":[]}` | ------------------------------------------------------------------------ |
 | fullnameOverride | string | `""` |  |
 | global.apiKey | string | `""` |  |
+| global.backendURL | string | `"https://api.costgraph.ai"` |  |
 | global.clusterName | string | `""` |  |
 | global.existingSecret | string | `""` |  |
 | global.existingSecretKey | string | `""` |  |

--- a/charts/costgraph-operator/templates/operator-kubernetes-deployment.yaml
+++ b/charts/costgraph-operator/templates/operator-kubernetes-deployment.yaml
@@ -43,6 +43,10 @@ spec:
           env:
             - name: CLUSTER_NAME
               value: {{ .Values.global.clusterName | required "Cluster name must be provided" | quote }}
+            {{- with .Values.global.backendURL }}
+            - name: BACKEND_URL
+              value: {{ . | quote }}
+            {{- end }}
             - name: API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/costgraph-operator/templates/operator-prometheus-deployment.yaml
+++ b/charts/costgraph-operator/templates/operator-prometheus-deployment.yaml
@@ -39,6 +39,10 @@ spec:
           env:
             - name: CLUSTER_NAME
               value: {{ .Values.global.clusterName | required "Cluster name must be provided"  | quote }}
+            {{- with .Values.global.backendURL }}
+            - name: BACKEND_URL
+              value: {{ . | quote }}
+            {{- end }}
             - name: API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/costgraph-operator/values.yaml
+++ b/charts/costgraph-operator/values.yaml
@@ -12,6 +12,9 @@ global:
   # existingSecretKey: key within existingSecret that holds the API key value.
   # Defaults to "apiKey" when not specified.
   existingSecretKey: ""
+  # backendURL is the base URL of the Costgraph API. Leave empty to omit the
+  # BACKEND_URL env var and rely on the service's built-in default.
+  backendURL: "https://api.costgraph.ai"
   namespace: "costgraph"
   # Flag to enable use of our custom image in the cadvisor chart
   security:


### PR DESCRIPTION
This pull request updates the Helm chart for the Costgraph Operator to support configuring a custom backend URL for the service. The main changes add a new `backendURL` value, which, if set, injects a `BACKEND_URL` environment variable into the operator deployments.

Configuration improvements:

* Added a new `backendURL` field to `global` values in `values.yaml`, allowing users to specify the base URL of the Costgraph API. If left empty, the `BACKEND_URL` environment variable will not be set, and the service will use its built-in default.

Deployment template updates:

* Updated `operator-kubernetes-deployment.yaml` and `operator-prometheus-deployment.yaml` to conditionally add the `BACKEND_URL` environment variable to the deployment spec if `global.backendURL` is set. [[1]](diffhunk://#diff-02fd490a071adc5bc1e1f488af928212063ee136a79337f9229fcb047fd7c5e9R46-R49) [[2]](diffhunk://#diff-aaf7923dbe2b521b10640bcb543679cf16d22b5b40d18b3844eac9415d2aa5b3R42-R45)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable backend URL parameter to customize the backend endpoint for deployments.

* **Documentation**
  * Updated Helm chart documentation with new configuration option and version information.

* **Chores**
  * Bumped Helm chart version from 0.1.5 to 0.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->