### PR TITLE
fix: * does not support subresources and correct tag

### DIFF
--- a/charts/costgraph-operator/Chart.yaml
+++ b/charts/costgraph-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: costgraph-operator
 description: A Helm chart for the Costgraph operator
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "1.16.1"
 
 dependencies:

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -1,6 +1,6 @@
 # costgraph-operator
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
 
 A Helm chart for the Costgraph operator
 
@@ -16,7 +16,7 @@ A Helm chart for the Costgraph operator
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cadvisor | object | `{"enabled":true,"image":{"registry":"ghcr.io","repository":"baselinehq/cadvisor","tag":"v0.56.3-baseline"}}` | ------------------------------------------------------------------------ |
+| cadvisor | object | `{"enabled":true,"image":{"registry":"ghcr.io","repository":"baselinehq/cadvisor","tag":"0.56.3-baseline"}}` | ------------------------------------------------------------------------ |
 | dcgm-exporter | object | `{"enabled":false,"nodeSelector":{"accelerator":"nvidia"},"podAnnotations":{},"podLabels":{},"resources":{},"serviceMonitor":{"enabled":false},"tolerations":[]}` | ------------------------------------------------------------------------ |
 | fullnameOverride | string | `""` |  |
 | global.apiKey | string | `""` |  |

--- a/charts/costgraph-operator/templates/serviceaccount.yaml
+++ b/charts/costgraph-operator/templates/serviceaccount.yaml
@@ -21,6 +21,9 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["pods/proxy"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/costgraph-operator/values.yaml
+++ b/charts/costgraph-operator/values.yaml
@@ -46,7 +46,7 @@ cadvisor:
   image:
     registry: ghcr.io
     repository: baselinehq/cadvisor
-    tag: "v0.56.3-baseline"
+    tag: "0.56.3-baseline"
 
 # --------------------------------------------------------------------------
 # dcgm-exporter (subchart from NVIDIA)


### PR DESCRIPTION
This pull request updates the `costgraph-operator` Helm chart with minor improvements and fixes. The main changes include updating the chart version, adjusting image tag formatting, and expanding RBAC permissions to support pod proxy access.

**Helm chart metadata and image tag updates:**

* Bumped the Helm chart version from `0.1.6` to `0.1.7` in `Chart.yaml` to reflect the new changes.
* Fixed the `cadvisor` image tag in `values.yaml` by removing the leading `v` for consistency (`v0.56.3-baseline` → `0.56.3-baseline`).

**RBAC permissions:**

* Added a new RBAC rule in `serviceaccount.yaml` to allow `get` access to the `pods/proxy` subresource, which is required for certain proxy operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.1.7

* **Updates**
  * Helm chart version incremented to 0.1.7
  * cAdvisor container image tag updated for improved version alignment
  * Cluster role permissions expanded to support pod proxy operations
  * Chart documentation and default configuration values refined

<!-- end of auto-generated comment: release notes by coderabbit.ai -->