### PR TITLE
fix: bump chart version

### DIFF
--- a/charts/costgraph-operator/Chart.yaml
+++ b/charts/costgraph-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: costgraph-operator
 description: A Helm chart for the Costgraph operator
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.2.0"
 
 dependencies:

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -1,6 +1,6 @@
 # costgraph-operator
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for the Costgraph operator
 

--- a/charts/costgraph-operator/README.md
+++ b/charts/costgraph-operator/README.md
@@ -1,6 +1,6 @@
 # costgraph-operator
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for the Costgraph operator
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Helm chart documentation to reflect chart version 0.2.1.

- **Chores**
  - Incremented the Helm chart release version to 0.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->