### PR TITLE
ci: add CodeQL and Trivy security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "41 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/trivy-registry.yml
+++ b/.github/workflows/trivy-registry.yml
@@ -1,0 +1,66 @@
+name: Trivy registry scan
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    outputs:
+      refs: ${{ steps.render.outputs.refs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Render chart and collect image references
+        id: render
+        run: |
+          i=0
+          for repo in $(grep -oE 'https://[^ ]+' charts/costgraph-operator/Chart.yaml | sort -u); do
+            i=$((i + 1))
+            helm repo add "dep$i" "$repo"
+          done
+          helm dependency build charts/costgraph-operator
+          helm template costgraph charts/costgraph-operator \
+            --set rbac.requireClusterDiscovery=false \
+            --set global.apiKey=scan \
+            --set global.clusterName=scan \
+            | grep -hoE '^\s*image:\s*"?[^"\s]+"?' \
+            | sed -E 's/^\s*image:\s*//; s/"//g' \
+            | sort -u > images.txt
+          cat images.txt
+          echo "refs=$(jq -R -s -c 'split("\n") | map(select(length > 0))' images.txt)" >> "$GITHUB_OUTPUT"
+
+  scan:
+    needs: images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.images.outputs.refs) }}
+    steps:
+      - name: Log into ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan ${{ matrix.image }}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.image }}
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"

--- a/.github/workflows/trivy-source.yml
+++ b/.github/workflows/trivy-source.yml
@@ -1,0 +1,30 @@
+name: Trivy source scan
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Scan chart configuration
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: charts
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "1"


### PR DESCRIPTION
Adds CodeQL and/or Trivy security scanning to CI.

- `codeql.yml`: CodeQL analysis on PR, push to the default branch, and weekly, over the languages GitHub detects for this repo. Go builds configure GOPRIVATE with GO_GET_TOKEN so autobuild can resolve private modules.
- `trivy-source.yml`: filesystem scan (vuln, secret, misconfig), failing on fixable HIGH/CRITICAL.
- `trivy-registry.yml`: nightly scan of the published image.

Trivy reports to the job log only; SARIF upload is deferred until code scanning upload works (needs `actions: read` on the job). CodeQL uploads its own results.