### PR TITLE
ci: pin scan actions by commit

### DIFF
--- a/.github/workflows/trivy-registry.yml
+++ b/.github/workflows/trivy-registry.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Render chart and collect image references
         id: render
@@ -49,14 +49,14 @@ jobs:
         image: ${{ fromJson(needs.images.outputs.refs) }}
     steps:
       - name: Log into ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Scan ${{ matrix.image }}
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ matrix.image }}

--- a/.github/workflows/trivy-source.yml
+++ b/.github/workflows/trivy-source.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Scan chart configuration
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           scan-ref: charts


### PR DESCRIPTION
Repins the Trivy action by commit sha - the previous `0.28.0` tag does not exist upstream, so the scan job could not start. Also pins `docker/login-action` and `azure/setup-helm` by commit.